### PR TITLE
fix: Restrict notebook to v6.x

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - python-graphviz
   - jupyterlab
   - matplotlib
-  - notebook
+  - notebook<7
   - numpy<2
   - pip
   - dask-labextension


### PR DESCRIPTION
* Restrict notebook to v6.x to avoid a deployment issue on BinderHub.