### PR TITLE
revert: Remove notebook v6.x restriction

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - python-graphviz
   - jupyterlab
   - matplotlib
-  - notebook<7
+  - notebook
   - numpy<2
   - pip
   - dask-labextension


### PR DESCRIPTION
Fengping on the SSL team fixed things on the BinderHub so `notebook` `v7` works now.